### PR TITLE
Fixed find-trip rendering after rerouting from other page

### DIFF
--- a/lavugio-front/src/app/features/find-trip/find-trip/find-trip.ts
+++ b/lavugio-front/src/app/features/find-trip/find-trip/find-trip.ts
@@ -94,9 +94,14 @@ export class FindTrip implements OnInit, OnDestroy {
   ngOnInit() {
     this.totalSteps = this.wizardState.getTotalSteps();
 
+    // Reset to first step when component is initialized
+    this.wizardState.reset();
+
     this.wizardState.currentStepIndex$.pipe(takeUntil(this.destroy$)).subscribe((index) => {
       this.currentStep = index;
       this.currentTitle = this.wizardState.getStepInfo(index).title;
+      // Trigger change detection to ensure map renders properly
+      this.cdr.detectChanges();
     });
 
     const savedDestinations = this.wizardState.getStepData('destinations');


### PR DESCRIPTION
This pull request improves the stability and lifecycle management of the map component used in the trip-finding feature. The main changes ensure the map is properly reset and cleaned up when the relevant components are initialized or destroyed, preventing issues like map duplication or memory leaks. Additionally, change detection is triggered at key moments to ensure the UI updates correctly.

**Map component lifecycle improvements:**

* Added `OnDestroy` lifecycle hook to `MapComponent` and implemented logic in `ngOnDestroy` to safely remove the map and route control, including error handling to prevent application crashes if removal fails. (`lavugio-front/src/app/shared/components/map/map.ts`) [[1]](diffhunk://#diff-5d08756d2f913f39dd6c72e34da394e391b34805a1c3141c102b1638f08298c1L1-R1) [[2]](diffhunk://#diff-5d08756d2f913f39dd6c72e34da394e391b34805a1c3141c102b1638f08298c1L14-R22) [[3]](diffhunk://#diff-5d08756d2f913f39dd6c72e34da394e391b34805a1c3141c102b1638f08298c1R153-R168)
* Updated the `initMap` method to clean up any existing map instance before initializing a new one, ensuring only a single map is present at any time. This includes clearing the map container and resetting internal state. (`lavugio-front/src/app/shared/components/map/map.ts`) [[1]](diffhunk://#diff-5d08756d2f913f39dd6c72e34da394e391b34805a1c3141c102b1638f08298c1R31-R43) [[2]](diffhunk://#diff-5d08756d2f913f39dd6c72e34da394e391b34805a1c3141c102b1638f08298c1R67-R68)

**Trip finding workflow improvements:**

* Modified `FindTrip` component to reset the wizard state to the first step on initialization and to trigger Angular change detection when the step changes, ensuring UI elements like the map render correctly. (`lavugio-front/src/app/features/find-trip/find-trip/find-trip.ts`)