### PR TITLE
Fixed driver activating and deactivating logic

### DIFF
--- a/lavugio-back/src/main/java/com/backend/lavugio/controller/user/DriverController.java
+++ b/lavugio-back/src/main/java/com/backend/lavugio/controller/user/DriverController.java
@@ -27,14 +27,17 @@ import com.backend.lavugio.service.user.DriverActivityService;
 import com.backend.lavugio.service.user.DriverRegistrationTokenService;
 import com.backend.lavugio.service.utils.DateTimeParserService;
 
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
 import com.backend.lavugio.service.user.DriverAvailabilityService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/lavugio-back/src/main/java/com/backend/lavugio/repository/user/DriverRepository.java
+++ b/lavugio-back/src/main/java/com/backend/lavugio/repository/user/DriverRepository.java
@@ -18,4 +18,5 @@ public interface DriverRepository extends JpaRepository<Driver, Long> {
     List<Driver> findByVehicleIsNull();
     long countByIsDrivingTrue();
     boolean existsByVehicle(Vehicle vehicle);
+    List<Driver> findByIsActiveTrue();
 }

--- a/lavugio-back/src/main/java/com/backend/lavugio/service/user/DriverDeactivationService.java
+++ b/lavugio-back/src/main/java/com/backend/lavugio/service/user/DriverDeactivationService.java
@@ -1,0 +1,8 @@
+package com.backend.lavugio.service.user;
+
+public interface DriverDeactivationService {
+    
+    void checkAndDeactivateDrivers();
+    
+    void onStartup();
+}

--- a/lavugio-back/src/main/java/com/backend/lavugio/service/user/impl/DriverDeactivationServiceImpl.java
+++ b/lavugio-back/src/main/java/com/backend/lavugio/service/user/impl/DriverDeactivationServiceImpl.java
@@ -1,0 +1,64 @@
+package com.backend.lavugio.service.user.impl;
+
+import com.backend.lavugio.model.user.Driver;
+import com.backend.lavugio.service.user.DriverActivityService;
+import com.backend.lavugio.service.user.DriverAvailabilityService;
+import com.backend.lavugio.service.user.DriverDeactivationService;
+import com.backend.lavugio.service.user.DriverService;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import org.springframework.context.event.EventListener;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class DriverDeactivationServiceImpl implements DriverDeactivationService {
+
+    @Autowired
+    private DriverService driverService;
+    @Autowired
+    private DriverAvailabilityService driverAvailabilityService;
+    @Autowired
+    private DriverActivityService driverActivityService;
+
+
+    //@Scheduled(cron = "0 */15 * * * *") - runs every 15 minutes
+    @Scheduled(fixedRate = 10000) // runs every 10 seconds for testing purposes
+    @Transactional
+    public void checkAndDeactivateDrivers() {
+        System.out.println("[" + LocalDateTime.now() + "] Checking drivers...");
+
+        List<Driver> activeDrivers = driverService.getActiveDrivers();
+
+        for (Driver driver : activeDrivers) {
+            if (shouldDeactivateDriver(driver)) {
+                driverService.deactivateDriver(driver.getId());
+            }
+        }
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void onStartup() {
+        System.out.println("Application started - deactivating all active drivers...");
+
+        List<Driver> activeDrivers = driverService.getActiveDrivers();
+
+        for (Driver driver : activeDrivers) {
+            driverService.deactivateDriver(driver.getId());
+        }
+
+        System.out.println("Deactivated " + activeDrivers.size() + " drivers on startup");
+    }
+
+    private boolean shouldDeactivateDriver(Driver driver) {
+        Duration activeTime = driverActivityService.getActiveTimeIn24Hours(driver.getId());
+        return activeTime.compareTo(Duration.ofHours(8)) >= 0;
+    }
+}

--- a/lavugio-back/src/main/java/com/backend/lavugio/service/user/impl/DriverServiceImpl.java
+++ b/lavugio-back/src/main/java/com/backend/lavugio/service/user/impl/DriverServiceImpl.java
@@ -203,7 +203,7 @@ public class DriverServiceImpl implements DriverService {
 
     @Override
     public List<Driver> getActiveDrivers() {
-        return driverRepository.findByIsDrivingTrue();
+        return driverRepository.findByIsActiveTrue();
     }
 
     @Override

--- a/lavugio-front/src/app/features/view-profile/components/profile-info-section/profile-info-section.html
+++ b/lavugio-front/src/app/features/view-profile/components/profile-info-section/profile-info-section.html
@@ -96,13 +96,19 @@
   <app-profile-info-row [label]="'Baby Friendly'" [value]="profile.vehicleBabyFriendly ?? false" [isBoolean]="true" (valueChanged)="onFieldChanged('vehicleBabyFriendly', $event)">
   </app-profile-info-row>
   
-  <app-profile-info-row
-    [label]="'Active in last 24h'"
-    [value]="getTimeActive()"
-    [editable]="false"
-    [singleLineLabel]="true"
-  >
-  </app-profile-info-row>
+  <!-- Active time row with custom styling -->
+  <div class="border-b-2 border-[#606C38] pb-2 flex flex-col items-center justify-between sm:flex-row sm:items-baseline sm:gap-3">
+    <span class="text-md text-[#606C38] sm:w-1/3 whitespace-nowrap">
+      Active in last 24h
+    </span>
+    <span 
+      class="font-medium text-lg"
+      [class.text-red-600]="hasExceeded8Hours()"
+      [class.text-[#BC6C25]]="!hasExceeded8Hours()"
+    >
+      <b>{{ getTimeActive() }}</b>
+    </span>
+  </div>
 }
 
 <!-- Buttons -->
@@ -120,7 +126,13 @@
       @if (isDriverActive()) {
         <app-button variant="dark-brown" (click)="onDeactivateClick()"> Deactivate </app-button>
       } @else {
-        <app-button variant="dark-brown" (click)="onActivateClick()"> Activate </app-button>
+        <app-button 
+          variant="dark-brown" 
+          (click)="onActivateClick()"
+          [disabled]="hasExceeded8Hours()"
+        > 
+          Activate 
+        </app-button>
       }
     </div>
     }

--- a/lavugio-front/src/app/shared/components/navbar/navbar.ts
+++ b/lavugio-front/src/app/shared/components/navbar/navbar.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, signal, NgZone, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, signal, NgZone, ChangeDetectorRef, computed } from '@angular/core';
 import { Links } from './links/links';
 import { Logo } from './links/logo/logo';
 import { Link } from './links/link/link';
@@ -31,6 +31,8 @@ export class Navbar implements OnInit {
   hasLatestRide = signal(false);
   latestRideId = signal(0);
   latestRideStatus = signal("");
+  timeActiveDuration = signal<number>(0);
+  hasExceeded8Hours = computed(() => this.timeActiveDuration() >= 480);
 
   constructor(
     private authService: AuthService,
@@ -100,6 +102,7 @@ export class Navbar implements OnInit {
       next: (driver) => {
         this.driverActive = driver.active || false;
         this.driverStatusService.updateLocalStatus(this.driverActive);
+        this.fetchActiveTime();
       },
       error: (error) => {
         console.error('Failed to load driver status', error);
@@ -115,6 +118,17 @@ export class Navbar implements OnInit {
     const newStatus = !this.driverActive;
 
     if (newStatus) {
+      // Check if driver has exceeded 8 hours
+      if (this.hasExceeded8Hours()) {
+        this.statusLoading = false;
+        this.notificationService.showNotification(
+          'You have reached the maximum 8 hours of active time in the last 24 hours',
+          'error'
+        );
+        this.cdr.detectChanges();
+        return;
+      }
+      
       // Activate driver - need to get coordinates
       navigator.geolocation.getCurrentPosition(
         (position) => {
@@ -224,5 +238,32 @@ export class Navbar implements OnInit {
             }
           },
       });
+  }
+
+  private fetchActiveTime(): void {
+    this.driverService.getDriverActiveLast24Hours().subscribe({
+      next: (response) => {
+        this.formatAndStoreDuration(response.timeActive);
+      },
+      error: (error) => {
+        console.error('Error fetching active time:', error);
+        this.timeActiveDuration.set(0);
+      }
+    });
+  }
+
+  private formatAndStoreDuration(duration: string): void {
+    const regex = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?/;
+    const match = duration.match(regex);
+    
+    if (!match) {
+      this.timeActiveDuration.set(0);
+      return;
+    }
+    
+    const hours = parseInt(match[1] || '0');
+    const minutes = parseInt(match[2] || '0');
+    
+    this.timeActiveDuration.set(hours * 60 + minutes);
   }
 }


### PR DESCRIPTION

This pull request introduces a backend service to automatically deactivate drivers who have exceeded 8 hours of active time in the last 24 hours, and updates the frontend to enforce this 8-hour limit in both the profile and navbar components. The changes ensure that drivers cannot activate themselves if they've reached the maximum allowed active time, and provide clear feedback in the UI.

**Backend: Driver Deactivation Automation**

* Added `DriverDeactivationService` and its implementation, which:
  * Deactivates all active drivers on application startup.
  * Periodically checks and deactivates drivers who have been active for 8 or more hours in the last 24 hours. [[1]](diffhunk://#diff-38a3deddfaa49a09cb736c84b0f5996f3d793b9699535681c01bf01c3e4cf349R1-R8) [[2]](diffhunk://#diff-3cfc17b924543554ab3f283542e6f69367874fab88f12315544166aebc57ebfdR1-R64)
* Updated `DriverRepository` and `DriverServiceImpl` to support querying only currently active drivers. [[1]](diffhunk://#diff-f7224a17f833c8702434352c1939f6e58eff9299ea1aa3a77a2721d14d366badR21) [[2]](diffhunk://#diff-9ad2fb393bd6b7caa5f5356762519efce7b4c7ec8612db28731c0a70640722b6L206-R206)
* Added necessary imports for scheduling and transaction management.

**Frontend: Enforcing and Displaying the 8-Hour Limit**

* Profile page (`ProfileInfoSection`):
  * Displays active time with conditional styling if the 8-hour limit is exceeded.
  * Disables the "Activate" button and shows a dialog if a driver tries to activate after exceeding the limit. [[1]](diffhunk://#diff-1a221b8e3fb732e974a22b7525b03e92d6d527b5c33f0eb890f54e642ee919d5L99-R111) [[2]](diffhunk://#diff-1a221b8e3fb732e974a22b7525b03e92d6d527b5c33f0eb890f54e642ee919d5L123-R135) [[3]](diffhunk://#diff-d62a6f588bb014106d7e1c7cb4c8027ca61871c412904f3d6d7f9512e1c255d6R32-R37) [[4]](diffhunk://#diff-d62a6f588bb014106d7e1c7cb4c8027ca61871c412904f3d6d7f9512e1c255d6R116-R126) [[5]](diffhunk://#diff-d62a6f588bb014106d7e1c7cb4c8027ca61871c412904f3d6d7f9512e1c255d6L302-R328)
* Navbar:
  * Fetches and stores the driver's active time, computes if the 8-hour limit is exceeded, and prevents activation with a notification if so. [[1]](diffhunk://#diff-27d95e39d6ced03c38f491681bb59443ee774008b278a76971c07512f3329fbeL1-R1) [[2]](diffhunk://#diff-27d95e39d6ced03c38f491681bb59443ee774008b278a76971c07512f3329fbeR34-R35) [[3]](diffhunk://#diff-27d95e39d6ced03c38f491681bb59443ee774008b278a76971c07512f3329fbeR105) [[4]](diffhunk://#diff-27d95e39d6ced03c38f491681bb59443ee774008b278a76971c07512f3329fbeR121-R131) [[5]](diffhunk://#diff-27d95e39d6ced03c38f491681bb59443ee774008b278a76971c07512f3329fbeR242-R268)

These changes collectively automate driver deactivation for regulatory compliance and improve the user experience by proactively preventing over-activation.